### PR TITLE
console entry point

### DIFF
--- a/nwbn_conversion_tools/gui/command_line.py
+++ b/nwbn_conversion_tools/gui/command_line.py
@@ -1,0 +1,21 @@
+# Opens the NWB conversion GUI
+# authors: Luiz Tauffer and Ben Dichter
+# ------------------------------------------------------------------------------
+from nwbn_conversion_tools.gui.nwbn_conversion_gui import nwbn_conversion_gui
+
+def main():
+    metafile = 'template_metafile.yml'
+    conversion_module = 'template_conversion_module.py'
+
+    source_paths = {}
+    source_paths['file1'] = {'type': 'file', 'path': ''}
+    source_paths['file2'] = {'type': 'file', 'path': ''}
+
+    kwargs_fields = {}
+
+    nwbn_conversion_gui(
+        metafile=metafile,
+        conversion_module=conversion_module,
+        source_paths=source_paths,
+        kwargs_fields=kwargs_fields
+    )

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,8 @@ setup(
         'pandas', 'jupyter', 'matplotlib', 'h5py', 'pyyaml',
         'spikeextractors', 'spikesorters', 'spiketoolkit', 'herdingspikes',
         'PySide2', 'nwbwidgets', 'psutil', 'voila'
-    ])
+    ],
+    entry_points = {
+        'console_scripts': ['nwbn-gui=nwbn_conversion_tools.gui.command_line:main'],
+    }
+)


### PR DESCRIPTION
creates a console shortcut to open an empty GUI.
```shell
nwbn-gui
```

it might be extended to include optional arguments, such as metadata file path